### PR TITLE
feat: 냉장고 재료 저장 API 구현

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/controller/IngredientController.java
@@ -1,16 +1,18 @@
 package com.mohaemukzip.mohaemukzip_be.domain.ingredient.controller;
 
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.dto.IngredientRequestDTO;
 import com.mohaemukzip.mohaemukzip_be.domain.ingredient.dto.IngredientResponseDTO;
 import com.mohaemukzip.mohaemukzip_be.domain.ingredient.entity.enums.Category;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.service.IngredientCommandService;
 import com.mohaemukzip.mohaemukzip_be.domain.ingredient.service.IngredientQueryService;
+import com.mohaemukzip.mohaemukzip_be.domain.member.entity.Member;
 import com.mohaemukzip.mohaemukzip_be.global.response.ApiResponse;
+import com.mohaemukzip.mohaemukzip_be.global.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -22,16 +24,33 @@ import java.util.List;
 public class IngredientController {
 
     private final IngredientQueryService ingredientQueryService;
+    private final IngredientCommandService ingredientCommandService;
 
+    // 재료 검색
     @GetMapping
-    public ApiResponse<List<IngredientResponseDTO>> searchIngredients(
+    public ApiResponse<List<IngredientResponseDTO.Detail>> searchIngredients(
       @RequestParam(name = "query", required = false) String query,
       @RequestParam(name = "category", required = false) Category category
     ) {
-        List<IngredientResponseDTO> response = ingredientQueryService.getIngredients(query,category);
+
+        List<IngredientResponseDTO.Detail> response = ingredientQueryService.getIngredients(query,category);
 
         return ApiResponse.onSuccess(response);
     }
+
+    // 냉장고 재료 추가
+    @PostMapping("/me")
+    public ApiResponse<IngredientResponseDTO.AddFridgeResult> addFridgeIngredient(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody IngredientRequestDTO.AddFridge request
+    ) {
+        Member member = customUserDetails.getMember();
+
+        IngredientResponseDTO.AddFridgeResult result = ingredientCommandService.addFridgeIngredient(member.getId(), request);
+
+        return ApiResponse.onSuccess(result);
+    }
+
 }
 
 

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/dto/IngredientRequestDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/dto/IngredientRequestDTO.java
@@ -1,9 +1,21 @@
 package com.mohaemukzip.mohaemukzip_be.domain.ingredient.dto;
 
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.entity.enums.StorageType;
 import lombok.Builder;
 import lombok.Getter;
 
-@Getter
-@Builder
+import java.time.LocalDate;
+
+
 public class IngredientRequestDTO {
+
+    //냉장고 재료 추가
+    @Getter
+    @Builder
+    public static class AddFridge {
+        private Long ingredientId;
+        private StorageType storageType;
+        private LocalDate expireDate;
+        private Double weight;
+    }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/dto/IngredientResponseDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/dto/IngredientResponseDTO.java
@@ -1,26 +1,35 @@
 package com.mohaemukzip.mohaemukzip_be.domain.ingredient.dto;
 
 import com.mohaemukzip.mohaemukzip_be.domain.ingredient.entity.Ingredient;
-import com.mohaemukzip.mohaemukzip_be.domain.ingredient.entity.enums.Category;
 import lombok.Builder;
 import lombok.Getter;
 
-@Getter
-@Builder
 public class IngredientResponseDTO {
-    private Long id;
-    private String name;
-    private String category;
-    private String unit;
 
-    //엔티티 -> dto 변환 메서드
-    public static IngredientResponseDTO from(Ingredient ingredient) {
+    //1. 재료 조회 api
+    @Getter
+    @Builder
+    public static class Detail {
+        private Long id;
+        private String name;
+        private String category;
+        private String unit;
 
-        return IngredientResponseDTO.builder()
-                .id(ingredient.getId())
-                .name(ingredient.getName())
-                .category(ingredient.getCategory() != null ? ingredient.getCategory().getLabel() : null)
-                .unit(ingredient.getUnit() != null ? ingredient.getUnit().getLabel() : null)
-                .build();
+        // 엔티티 -> DTO 변환 메서드
+        public static Detail from(Ingredient ingredient) {
+            return Detail.builder()
+                    .id(ingredient.getId())
+                    .name(ingredient.getName())
+                    .category(ingredient.getCategory() != null ? ingredient.getCategory().getLabel() : null)
+                    .unit(ingredient.getUnit() != null ? ingredient.getUnit().getLabel() : null)
+                    .build();
+        }
+    }
+
+    //2. 냉장고에 추가 api
+    @Getter
+    @Builder
+    public static class AddFridgeResult {
+        private Long memberIngredientId;
     }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientCommandService.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientCommandService.java
@@ -1,4 +1,11 @@
 package com.mohaemukzip.mohaemukzip_be.domain.ingredient.service;
 
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.dto.IngredientRequestDTO;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.dto.IngredientResponseDTO;
+
 public interface IngredientCommandService {
+
+    //냉장고에 재료 추가 기능
+    IngredientResponseDTO.AddFridgeResult addFridgeIngredient(Long memberId, IngredientRequestDTO.AddFridge request);
+
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientCommandServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientCommandServiceImpl.java
@@ -1,9 +1,53 @@
 package com.mohaemukzip.mohaemukzip_be.domain.ingredient.service;
 
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.dto.IngredientRequestDTO;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.dto.IngredientResponseDTO;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.entity.Ingredient;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.entity.MemberIngredient;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.repository.IngredientRepository;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.repository.MemberIngredientRepository;
+import com.mohaemukzip.mohaemukzip_be.domain.member.entity.Member;
+import com.mohaemukzip.mohaemukzip_be.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class IngredientCommandServiceImpl implements IngredientCommandService {
+
+    private final IngredientRepository ingredientRepository;
+    private final MemberRepository memberRepository;
+    private final MemberIngredientRepository memberIngredientRepository;
+
+
+    @Override
+    public IngredientResponseDTO.AddFridgeResult addFridgeIngredient(Long memberId, IngredientRequestDTO.AddFridge request) {
+
+        // 회원 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. id=" + memberId));
+
+        // 재료 조회
+        Ingredient ingredient = ingredientRepository.findById(request.getIngredientId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 재료입니다. id=" + request.getIngredientId()));
+
+        //엔티티 생성
+        MemberIngredient memberIngredient = MemberIngredient.builder()
+                .member(member)
+                .ingredient(ingredient)
+                .storageType(request.getStorageType()) // 냉장/냉동/실온
+                .expireDate(request.getExpireDate())   // 유통기한
+                .weight(request.getWeight())           // 용량
+                .build();
+
+        // DB에 insert
+        MemberIngredient saved = memberIngredientRepository.save(memberIngredient);
+
+        return IngredientResponseDTO.AddFridgeResult.builder()
+                .memberIngredientId(saved.getId())
+                .build();
+
+    }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientQueryService.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientQueryService.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface IngredientQueryService {
 
     //키워드, 카테고리 주면 재료 목록(dto 리스트) 가져옴
-    List<IngredientResponseDTO> getIngredients(String keyword, Category category);
+    List<IngredientResponseDTO.Detail> getIngredients(String keyword, Category category);
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientQueryServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientQueryServiceImpl.java
@@ -19,11 +19,11 @@ public class IngredientQueryServiceImpl implements IngredientQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<IngredientResponseDTO> getIngredients(String keyword, Category category) {
+    public List<IngredientResponseDTO.Detail> getIngredients(String keyword, Category category) {
 
         List<Ingredient> ingredients;
 
-        // 키워드 + 카테고리가 있는 경우 조회
+        // 1. 키워드 + 카테고리가 있는 경우 조회
         if (keyword != null && !keyword.isBlank() && category != null) {
             ingredients = ingredientRepository.findByNameContainingAndCategory(keyword, category);
         }
@@ -41,7 +41,7 @@ public class IngredientQueryServiceImpl implements IngredientQueryService {
         }
 
         return ingredients.stream()
-                .map(IngredientResponseDTO::from)
+                .map(IngredientResponseDTO.Detail::from)
                 .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientCommandServiceTest.java
+++ b/src/test/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientCommandServiceTest.java
@@ -1,0 +1,83 @@
+package com.mohaemukzip.mohaemukzip_be.domain.ingredient.service;
+
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.dto.IngredientRequestDTO;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.dto.IngredientResponseDTO;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.entity.Ingredient;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.entity.MemberIngredient;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.entity.enums.StorageType;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.repository.IngredientRepository;
+import com.mohaemukzip.mohaemukzip_be.domain.ingredient.repository.MemberIngredientRepository;
+import com.mohaemukzip.mohaemukzip_be.domain.member.entity.Member;
+import com.mohaemukzip.mohaemukzip_be.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class IngredientCommandServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private IngredientRepository ingredientRepository;
+
+    @Mock
+    private MemberIngredientRepository memberIngredientRepository;
+
+    @InjectMocks
+    private IngredientCommandServiceImpl ingredientCommandService;
+
+    @Test
+    @DisplayName("냉장고 재료 저장 테스트 ")
+    void addFridgeIngredient_Success() {
+
+        // Given
+        Long memberId = 1L;
+        Long ingredientId = 10L;
+
+        IngredientRequestDTO.AddFridge request = IngredientRequestDTO.AddFridge.builder()
+                .ingredientId(ingredientId)
+                .storageType(StorageType.FREEZER)
+                .expireDate(LocalDate.now())
+                .weight(100.0)
+                .build();
+
+        Member mockMember = Member.builder().id(memberId).build();
+        Ingredient mockIngredient = Ingredient.builder().id(ingredientId).build();
+        MemberIngredient mockSaved = MemberIngredient.builder()
+                .id(500L)
+                .storageType(request.getStorageType())
+                .expireDate(request.getExpireDate())
+                .weight(request.getWeight())
+                .build();
+
+        // Mocking 설정
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(mockMember));
+        when(ingredientRepository.findById(ingredientId)).thenReturn(Optional.of(mockIngredient));
+        when(memberIngredientRepository.save(any(MemberIngredient.class))).thenReturn(mockSaved);
+
+        // When
+        IngredientResponseDTO.AddFridgeResult result = ingredientCommandService.addFridgeIngredient(memberId, request);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(500L, result.getMemberIngredientId());
+
+        verify(memberIngredientRepository, times(1)).save(any(MemberIngredient.class));
+        assertEquals(StorageType.FREEZER, mockSaved.getStorageType());
+        assertEquals(100.0, mockSaved.getWeight());
+
+    }
+}


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- feat/11-add-fridge 

## 🔑 주요 변경사항

- 냉장고 재료 저장 api 비즈니스 로직 구현 (controller, service, repository)
- [IngredientResponseDTO] : 각 케이스별로 DTO 분리 

## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 냉장고 재료 추가 기능: 저장 유형, 만료 날짜, 무게 정보와 함께 냉장고에 재료를 저장할 수 있습니다
  * 재료 검색 결과의 응답 구조를 개선하여 더욱 상세한 정보 제공

* **테스트**
  * 냉장고 재료 추가 기능의 동작을 검증하는 테스트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->