### PR TITLE
chore: prod JPA ddl-auto validate로 원상 복구

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -9,7 +9,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     show-sql: false
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
 
   data:
     redis:


### PR DESCRIPTION
이전 PR에서 prod 프로파일에 일시적으로 적용했던 `spring.jpa.hibernate.ddl-auto: update` 설정을 원래대로 `validate` 로 되돌립니다.
## 🔑 주요 변경사항

- `spring.jpa.hibernate.ddl-auto: update` → `validate`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **설정**
  * 프로덕션 환경의 데이터베이스 스키마 검증 정책이 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->