### PR TITLE
feat: 오늘의 퀘스트 로직 수정

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/home/converter/HomeConverter.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/home/converter/HomeConverter.java
@@ -1,6 +1,8 @@
 package com.mohaemukzip.mohaemukzip_be.domain.home.converter;
 
 import com.mohaemukzip.mohaemukzip_be.domain.home.dto.HomeResponseDTO;
+import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.MemberMission;
+import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.enums.MissionStatus;
 import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.Mission;
 import com.mohaemukzip.mohaemukzip_be.domain.recipe.entity.Recipe;
 import com.mohaemukzip.mohaemukzip_be.global.service.LevelService;
@@ -33,13 +35,15 @@ public class HomeConverter {
                 .build();
     }
 
-    public static HomeResponseDTO.TodayMissionDto toTodayMissionDto(Mission mission, boolean isDone)  {
+    public static HomeResponseDTO.TodayMissionDto toTodayMissionDto(MemberMission memberMission)  {
+        Mission mission = memberMission.getMission();
         return HomeResponseDTO.TodayMissionDto.builder()
                 .missionId(mission.getId())
                 .title(mission.getTitle())
                 .description(mission.getDescription())
                 .reward(mission.getReward())
-                .isCompleted(isDone)
+                .keyword(mission.getKeyword())
+                .status(memberMission.getStatus().name())
                 .build();
     }
 

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/home/dto/HomeResponseDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/home/dto/HomeResponseDTO.java
@@ -42,7 +42,8 @@ public class HomeResponseDTO {
         private String title;
         private String description;
         private Integer reward;
-        private Boolean isCompleted;
+        private String keyword;
+        private String status; // "ASSIGNED", "COMPLETED", "FAILED"
     }
 
     @Getter

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/home/service/HomeService.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/home/service/HomeService.java
@@ -2,7 +2,7 @@ package com.mohaemukzip.mohaemukzip_be.domain.home.service;
 
 import com.mohaemukzip.mohaemukzip_be.domain.home.converter.HomeConverter;
 import com.mohaemukzip.mohaemukzip_be.domain.home.dto.HomeResponseDTO;
-import com.mohaemukzip.mohaemukzip_be.domain.home.entity.enums.MissionStatus;
+import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.enums.MissionStatus;
 import com.mohaemukzip.mohaemukzip_be.domain.member.entity.Member;
 import com.mohaemukzip.mohaemukzip_be.domain.member.repository.MemberRepository;
 import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.MemberMission;
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
+
+import static com.mohaemukzip.mohaemukzip_be.domain.mission.converter.MissionConverter.toMemberMission;
 
 @Service
 @RequiredArgsConstructor
@@ -148,29 +150,53 @@ public class HomeService {
         return HomeConverter.toWeeklyCookingDto(cookingByDay);
     }
 
-    // 오늘의 미션 (현재는 도전완료까지 진행 안한 미션 중 하나를 랜덤하게 보여줌. 같은 날짜, 같은 사용자에겐 하루동안 지속하고
-    // 사용자마다 동일하지않음.
+    // 오늘의 미션 (도전완료까지 진행 안한 미션 중 하나를 랜덤하게 보여줌)
     private HomeResponseDTO.TodayMissionDto getTodayMission(Long memberId) {
 
-        // 1. 전체 미션 조회
-        List<Mission> allMissions = missionRepository.findAll();
-
-        if (allMissions.isEmpty()) return null;
-
-        // 2. 날짜 + 멤버ID 기반 시드
-        long seed = LocalDate.now().toEpochDay() + memberId;
-        Random random = new Random(seed);
-
-        // 3. 전체 미션 중 하나 선택
-        int index = random.nextInt(allMissions.size());
-        Mission mission = allMissions.get(index);
-
-        // 4. 선택된 미션이 완료되었는지 여부 DTO에 담아 보내기 (완료된 미션은 프론트에서 따로 표시해야하기 떄문에 추가함)
         LocalDate today = LocalDate.now();
-        boolean isDone = memberMissionRepository.existsByMemberIdAndMissionIdAndAssignedDateAndStatus(
-                memberId, mission.getId(), today, MissionStatus.COMPLETED);
 
-        return HomeConverter.toTodayMissionDto(mission, isDone);
+        // 1. 오늘 할당된 미션 조회 (할당된 미션 없으면 할당까지)
+        MemberMission memberMission = memberMissionRepository
+                .findByMemberIdAndAssignedDate(memberId, today)
+                .orElseGet(() -> assignTodayMission(memberId, today));
+
+        // 2. 오늘 완료 여부 정확히 반영
+        boolean isCompletedToday = memberMissionRepository
+                .existsByMemberIdAndMissionIdAndAssignedDateAndStatus(
+                        memberId,
+                        memberMission.getMission().getId(),
+                        today,
+                        MissionStatus.COMPLETED
+                );
+
+        if (isCompletedToday && memberMission.getStatus() != MissionStatus.COMPLETED) {
+            memberMission.completeToday();   // 상태 싱크 맞추기
+        }
+
+        return HomeConverter.toTodayMissionDto(memberMission);
+    }
+
+    private MemberMission assignTodayMission(Long memberId, LocalDate today) {
+
+        List<Mission> candidates = missionRepository.findAll()
+                .stream()
+                .filter(mission ->
+                        !memberMissionRepository.existsByMemberIdAndMissionId(
+                                memberId,
+                                mission.getId()
+                        )
+                )
+                .toList();
+
+        if (candidates.isEmpty()) {
+            throw new BusinessException(ErrorStatus.NO_AVAILABLE_MISSION);
+        }
+
+        Mission selected = candidates.get(new Random().nextInt(candidates.size()));
+
+        return memberMissionRepository.save(
+                toMemberMission(memberId, selected, today)
+        );
     }
 
     // 추천 레시피
@@ -178,5 +204,5 @@ public class HomeService {
         List<Recipe> recipes = recipeRepository.findTop5ByOrderByViewsDesc();
 
         return HomeConverter.toRecommendedRecipeDtos(recipes);
-}
+    }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/converter/MissionConverter.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/converter/MissionConverter.java
@@ -1,4 +1,20 @@
 package com.mohaemukzip.mohaemukzip_be.domain.mission.converter;
 
+import com.mohaemukzip.mohaemukzip_be.domain.member.entity.Member;
+import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.MemberMission;
+import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.Mission;
+import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.enums.MissionStatus;
+
+import java.time.LocalDate;
+
 public class MissionConverter {
+
+    public static MemberMission toMemberMission(Long memberId, Mission mission, LocalDate assignedDate) {
+        return MemberMission.builder()
+                .member(Member.builder().id(memberId).build())
+                .mission(mission)
+                .assignedDate(assignedDate)
+                .status(MissionStatus.ASSIGNED)
+                .build();
+    }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/entity/MemberMission.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/entity/MemberMission.java
@@ -1,6 +1,6 @@
 package com.mohaemukzip.mohaemukzip_be.domain.mission.entity;
 
-import com.mohaemukzip.mohaemukzip_be.domain.home.entity.enums.MissionStatus;
+import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.enums.MissionStatus;
 import com.mohaemukzip.mohaemukzip_be.domain.member.entity.Member;
 import com.mohaemukzip.mohaemukzip_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -16,7 +16,7 @@ import java.time.LocalDate;
 @Table(name = "member_missions", uniqueConstraints = {
         @UniqueConstraint(
                 name = "UQ_MEMBER_ASSIGNED_DATE",
-                columnNames = {"member_id", "assignedDate"}
+                columnNames = {"member_id", "assigned_date"}
         )
 })
 public class MemberMission extends BaseEntity {
@@ -34,7 +34,7 @@ public class MemberMission extends BaseEntity {
     @JoinColumn(name = "mission_id", nullable = false)
     private Mission mission;
 
-    @Column(name = "assignedDate")
+    @Column(name = "assigned_date",  nullable = false)
     private LocalDate assignedDate; // 오늘의 퀘스트 날짜
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/entity/enums/MissionStatus.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/entity/enums/MissionStatus.java
@@ -1,4 +1,4 @@
-package com.mohaemukzip.mohaemukzip_be.domain.home.entity.enums;
+package com.mohaemukzip.mohaemukzip_be.domain.mission.entity.enums;
 
 public enum MissionStatus {
     ASSIGNED,

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/repository/MemberMissionRepository.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/repository/MemberMissionRepository.java
@@ -1,6 +1,6 @@
 package com.mohaemukzip.mohaemukzip_be.domain.mission.repository;
 
-import com.mohaemukzip.mohaemukzip_be.domain.home.entity.enums.MissionStatus;
+import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.enums.MissionStatus;
 import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.MemberMission;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/response/code/status/ErrorStatus.java
@@ -66,6 +66,8 @@ public enum ErrorStatus implements BaseCode {
     RECIPE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "RECIPE4002", "이미 저장된 레시피입니다."),
     INVALID_RATING_VALUE(HttpStatus.BAD_REQUEST, "RECIPE4003",   "난이도는 1부터 5 사이의 값입니다."),
 
+    // 미션 관련 에러
+    NO_AVAILABLE_MISSION(HttpStatus.NOT_FOUND, "MISSION4001", "퀘스트로 할당할 미션이 남아있지 않습니다.")
     ;
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- feat/103/HomeService-TodayMisson


## 🔑 주요 변경사항

- MemberMission 필드명 수정 (assignedDate -> assigned_date)
- MissionStatus ENUM 위치 이동 (Home -> Mission)
- HomeService 에서 오늘 퀘스트 할당 및 고정 기능 구현


## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일일 미션에 상태 정보 표시(할당됨, 완료됨, 실패) 및 미션 키워드 추가
  * 미션 자동 할당 시스템 개선

* **개선사항**
  * 미션 상태 관리 로직 최적화
  * 이용 가능한 미션이 없을 때 사용자 안내 메시지 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->