### PR TITLE
refactor : 홈 서비스단 트랜잭션 분리

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/service/MissionAssignmentService.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/service/MissionAssignmentService.java
@@ -1,4 +1,4 @@
-package com.mohaemukzip.mohaemukzip_be.domain.home.service;
+package com.mohaemukzip.mohaemukzip_be.domain.mission.service;
 
 import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.MemberMission;
 import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.Mission;
@@ -16,8 +16,9 @@ import java.util.List;
 import java.util.Random;
 
 import static com.mohaemukzip.mohaemukzip_be.domain.mission.converter.MissionConverter.toMemberMission;
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
-// 오늘의 미션 할당 및 조회 서비스
+// 오늘의 미션 할당
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -27,36 +28,24 @@ public class MissionAssignmentService {
     private final MemberMissionRepository memberMissionRepository;
 
     //오늘의 미션 조회 또는 할당
-    @Transactional
-    public MemberMission getOrAssignTodayMission(Long memberId, LocalDate today) {
-        return memberMissionRepository.findByMemberIdAndAssignedDate(memberId, today)
-                .orElseGet(() -> {
-                    log.info("오늘의 미션 없음, 새로 할당 - memberId: {}", memberId);
-                    return assignTodayMission(memberId, today);
-                });
+    @Transactional(propagation = REQUIRES_NEW)
+    public MemberMission assignTodayMission(Long memberId, LocalDate today) {
+        return assign(memberId, today);
     }
 
-    /**
-     * 새로운 미션 할당
-     * - 아직 완료하지 않은 미션 중 랜덤 선택
-     */
-    private MemberMission assignTodayMission(Long memberId, LocalDate today) {
-        // 할당 가능한 미션 조회 (완료하지 않은 미션만)
+    private MemberMission assign(Long memberId, LocalDate today) {
         List<Mission> candidates = missionRepository.findAvailableMissions(memberId);
 
-        // 할당 가능한 미션이 없는 경우
         if (candidates.isEmpty()) {
             log.error("할당 가능한 미션 없음 - memberId: {}", memberId);
             throw new BusinessException(ErrorStatus.NO_AVAILABLE_MISSION);
         }
 
-        // 랜덤 선택
         Mission selected = candidates.get(new Random().nextInt(candidates.size()));
 
         log.info("미션 할당 완료 - memberId: {}, missionId: {}, title: {}",
                 memberId, selected.getId(), selected.getTitle());
 
-        // MemberMission 생성 및 저장
         return memberMissionRepository.save(
                 toMemberMission(memberId, selected, today)
         );

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/service/MissionQueryService.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/service/MissionQueryService.java
@@ -1,4 +1,22 @@
 package com.mohaemukzip.mohaemukzip_be.domain.mission.service;
 
-public interface MissionQueryService {
+import com.mohaemukzip.mohaemukzip_be.domain.mission.entity.MemberMission;
+import com.mohaemukzip.mohaemukzip_be.domain.mission.repository.MemberMissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MissionQueryService {
+
+    private final MemberMissionRepository memberMissionRepository;
+
+    @Transactional(readOnly = true)
+    public Optional<MemberMission> findTodayMission(Long memberId, LocalDate today) {
+        return memberMissionRepository.findByMemberIdAndAssignedDate(memberId, today);
+    }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/service/MissionQueryServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/service/MissionQueryServiceImpl.java
@@ -1,9 +1,0 @@
-package com.mohaemukzip.mohaemukzip_be.domain.mission.service;
-
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
-@Service
-@RequiredArgsConstructor
-public class MissionQueryServiceImpl implements MissionQueryService {
-}


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- refactor/133-home


## 🔑 주요 변경사항

- 현재 Mission 도메인은 단일 구현체만 존재하므로
불필요한 추상화를 피하고 인터페이스 없이 서비스 클래스로 구성했습니다.
향후 다중 구현이 필요한 시점에 인터페이스 도입을 고려할 예정입니다.

- 홈 화면 조회 로직은 다음과 같이 책임을 분리했습니다.
```
HomeQueryService (read-only)
 └─ 오늘의 미션 조회
     ├─ 존재 시: 기존 미션 반환
     └─ 미존재 시: MissionAssignmentService.assignTodayMission()
```

🔄 트랜잭션 설계 의도
- 홈 조회 API는 조회 성격이 강하므로 readOnly = true 트랜잭션을 유지했습니다.
- 반면, 오늘의 미션 할당은 side-effect를 가지는 쓰기 로직이므로 홈 조회 트랜잭션과 분리된 독립적인 쓰기 트랜잭션으로 처리했습니다. 
- 이를 위해 MissionAssignmentService에 @Transactional(propagation = REQUIRES_NEW)를 적용했습니다.

> 조회 실패 여부와 무관하게
오늘의 미션 할당이 독립적으로 관리되도록 하기 위한 의도적인 설계 선택입니다.

## Check List
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 홈 화면에 통계 기능 추가 (냉장고 점수, 요리 횟수, 난이도 평균, 월간 통계)
  * 요리 기록 달력 기능 추가
  
* **개선사항**
  * 오늘의 미션 조회 로직 개선 (사전 확인 및 할당 프로세스 최적화)
  * 홈 조회 서비스 트랜잭션 범위 조정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->