### PR TITLE
feat: 재료 추천 소비기한 받기 api 구현

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/controller/IngredientController.java
@@ -19,7 +19,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
 
 @Slf4j
@@ -140,6 +139,17 @@ public class IngredientController {
         return ApiResponse.onSuccess("소중한 의견 감사합니다 *.* ");
     }
 
+    @Operation(summary = "재료 추천 소비기한 조회")
+    @GetMapping("/{ingredientId}/recommended-expiration")
+    public ApiResponse<IngredientResponseDTO.RecommendedExpirationDate> getRecommendedExpirationDate(
+            @PathVariable Long ingredientId
+    ) {
+
+        IngredientResponseDTO.RecommendedExpirationDate response =
+                ingredientQueryService.getRecommendedExpirationDate(ingredientId);
+
+        return ApiResponse.onSuccess(response);
+    }
 }
 
 

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/dto/IngredientResponseDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/dto/IngredientResponseDTO.java
@@ -192,4 +192,25 @@ public class IngredientResponseDTO {
         }
     }
 
+    //10. 재료 추천 소비기한 받기
+    @Builder
+    public record RecommendedExpirationDate(
+            Long ingredientId,
+            String ingredientName,
+            LocalDate recommendedDate
+    ) {
+        public static RecommendedExpirationDate from(Ingredient ingredient, LocalDate registrationDate) {
+            LocalDate recommendedDate = null;
+            if (ingredient.getExpirationDays() != null && registrationDate != null) {
+                recommendedDate = registrationDate.plusDays(ingredient.getExpirationDays());
+            }
+
+            return RecommendedExpirationDate.builder()
+                    .ingredientId(ingredient.getId())
+                    .ingredientName(ingredient.getName())
+                    .recommendedDate(recommendedDate)
+                    .build();
+        }
+    }
+
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/entity/Ingredient.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/entity/Ingredient.java
@@ -31,4 +31,7 @@ public class Ingredient extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "category")
     private Category category;
+
+    @Column(name = "expiration_days")
+    private Integer expirationDays;
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientQueryService.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientQueryService.java
@@ -3,7 +3,6 @@ package com.mohaemukzip.mohaemukzip_be.domain.ingredient.service;
 import com.mohaemukzip.mohaemukzip_be.domain.ingredient.dto.IngredientResponseDTO;
 import com.mohaemukzip.mohaemukzip_be.domain.ingredient.entity.enums.Category;
 import org.springframework.data.domain.Page;
-
 import java.util.List;
 
 public interface IngredientQueryService {
@@ -19,4 +18,11 @@ public interface IngredientQueryService {
 
     //관리자용 재료 요청 목록 조회
     List<IngredientResponseDTO.AdminRequestList> getIngredientRequestList();
+
+    // 재료 소비기한 추천 조회
+    IngredientResponseDTO.RecommendedExpirationDate getRecommendedExpirationDate(
+            Long ingredientId
+    );
+
+
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientQueryServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/IngredientQueryServiceImpl.java
@@ -4,7 +4,8 @@ import com.mohaemukzip.mohaemukzip_be.domain.ingredient.dto.IngredientResponseDT
 import com.mohaemukzip.mohaemukzip_be.domain.ingredient.entity.*;
 import com.mohaemukzip.mohaemukzip_be.domain.ingredient.entity.enums.Category;
 import com.mohaemukzip.mohaemukzip_be.domain.ingredient.repository.*;
-import com.mohaemukzip.mohaemukzip_be.domain.member.repository.MemberRepository;
+import com.mohaemukzip.mohaemukzip_be.global.exception.BusinessException;
+import com.mohaemukzip.mohaemukzip_be.global.response.code.status.ErrorStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -91,6 +94,19 @@ public class IngredientQueryServiceImpl implements IngredientQueryService {
         return requests.stream()
                 .map(IngredientResponseDTO.AdminRequestList::from)
                 .toList();
+    }
+
+    // 재료 소비기한 추천
+    @Override
+    @Transactional(readOnly = true)
+    public IngredientResponseDTO.RecommendedExpirationDate getRecommendedExpirationDate(Long ingredientId) {
+
+        Ingredient ingredient = ingredientRepository.findById(ingredientId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.INGREDIENT_NOT_FOUND));
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        return IngredientResponseDTO.RecommendedExpirationDate.from(ingredient, today);
     }
 
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- feat/143-recommend-date 


## 🔑 주요 변경사항

- 재료 테이블에 소비기한 컬럼 추가 
- 현재 날짜를 기준으로 소비기한을 설정합니다. 


## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **재료별 권장 유통기한 조회** - 등록된 재료의 보관 가능 기간 정보를 기반으로 현재 날짜 기준의 권장 유통기한을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다. 각 재료의 상세 정보 조회 시 자동으로 계산된 권장 유통기한 정보를 함께 받을 수 있어, 식재료 관리의 편의성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->