### PR TITLE
feat: 통합 검색 API 레시피에서 요리명으로 수정

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/recipe/repository/DishProjection.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/recipe/repository/DishProjection.java
@@ -1,0 +1,6 @@
+package com.mohaemukzip.mohaemukzip_be.domain.recipe.repository;
+
+public interface DishProjection {
+    Long getId();
+    String getName();
+}

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/recipe/repository/DishRepository.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/recipe/repository/DishRepository.java
@@ -1,0 +1,14 @@
+package com.mohaemukzip.mohaemukzip_be.domain.recipe.repository;
+
+import com.mohaemukzip.mohaemukzip_be.domain.recipe.entity.Dish;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface DishRepository extends JpaRepository<Dish, Long> {
+
+    @Query("SELECT d.id as id, d.name as name FROM Dish d WHERE REPLACE(d.name, ' ', '') LIKE CONCAT('%', :keyword, '%')")
+    Page<DishProjection> findProjectedByNameContaining(@Param("keyword") String keyword, Pageable pageable);
+}

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/search/converter/SearchConverter.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/search/converter/SearchConverter.java
@@ -1,6 +1,7 @@
 package com.mohaemukzip.mohaemukzip_be.domain.search.converter;
 
 import com.mohaemukzip.mohaemukzip_be.domain.recipe.entity.Recipe;
+import com.mohaemukzip.mohaemukzip_be.domain.recipe.repository.DishProjection;
 import com.mohaemukzip.mohaemukzip_be.domain.recipe.repository.RecipeProjection;
 import com.mohaemukzip.mohaemukzip_be.domain.search.dto.SearchResponseDTO;
 import com.mohaemukzip.mohaemukzip_be.domain.search.dto.SearchResultDTO;
@@ -25,13 +26,20 @@ public class SearchConverter {
                 .build();
     }
 
+    public static SearchResultDTO toSearchResultDTO(DishProjection projection) {
+        return SearchResultDTO.builder()
+                .id(projection.getId())
+                .title(projection.getName())
+                .build();
+    }
+
     public static SearchResponseDTO toSearchResponseDTO(List<SearchResultDTO> results) {
         return SearchResponseDTO.builder()
                 .results(results)
                 .build();
     }
 
-    public static SearchResponseDTO toSearchResponseDTO(Page<RecipeProjection> page) {
+    public static SearchResponseDTO toSearchResponseDTO(Page<DishProjection> page) {
         List<SearchResultDTO> results = page.getContent().stream()
                 .map(SearchConverter::toSearchResultDTO)
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈
- 브랜치 : feat/147-search-api-refactor
- 이슈: #147 


## 🔑 주요 변경사항
**Repository Layer**
  - `DishRepository` 추가: Dish 엔티티 검색을 위한 리포지토리 생성. 
  - `DishProjection` 추가: 검색 성능 최적화를 위해 필요한 필드(id, name)만 조회하는 Projection 인터페이스 정의.
  - 검색 쿼리 구현: 공백을 무시하고 검색할 수 있도록 REPLACE 함수를 활용한 LIKE 검색 쿼리 적용.

**Service Layer (SearchQueryServiceImpl)**
  - 의존성 변경: RecipeRepository → DishRepository로 교체.
  - 검색 로직 변경: Recipe 제목 검색 로직을 Dish 이름 검색 로직으로 변경.
  - Redis 캐시 전략 수정
    - 캐시 키 변경: search::recipe::{keyword} → search::dish::v1::{keyword}.
    - v1 버전 태그를 추가하여 기존 캐시 데이터와의 충돌 방지 및 갱신 유도.
    - 디버깅을 위한 로그(Cache Hit/Miss, DB Result Count) 추가.

**Converter (SearchConverter)**
  - DishProjection을 `SearchResultDTO`로 변환하는 매핑 로직 추가.


## Check List
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 검색 기능에서 요리 검색 지원 추가

* **개선**
  * 검색 쿼리 처리 최적화로 더 빠른 결과 제공
  * 캐시 기반 검색 성능 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->