### PR TITLE
refactor: 홈 화면 현재 점수, 다음 레벨 필요 점수를 상대 점수로 변환

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/home/converter/HomeConverter.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/home/converter/HomeConverter.java
@@ -29,7 +29,7 @@ public class HomeConverter {
                 .level(levelProgress.currentLevel())
                 .title(levelProgress.title())
                 .monthlyCooking(monthlyCooking)
-                .score(score)
+                .score(levelProgress.currentScore())
                 .nextLevelScore(levelProgress.nextLevelScore())
                 .consecutiveDays(consecutiveDays)
                 .nickname(nickname)

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/service/LevelService.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/service/LevelService.java
@@ -59,8 +59,8 @@ public class LevelService {
             return new LevelProgressDto(
                     level,
                     title,
-                    currentScore,
-                    nextLevelScore,
+                    currentScore - LEVEL_SCORES[level],
+                    0,
                     0
             );
         }
@@ -70,8 +70,8 @@ public class LevelService {
         return new LevelProgressDto(
                 level,
                 title,
-                currentScore,
-                nextLevelScore,
+                currentScore - LEVEL_SCORES[level],
+                nextLevelScore - LEVEL_SCORES[level],
                 remainingScore
         );
     }


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- refactor/168-Home-Score


## 🔑 주요 변경사항

- LevelService에서 currentScore, nextLevelScore를 레밸 내 상대값으로 변환 (remainingScore는 변환 안해도 똑같아서 그대로 놔둠)


## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 수정 사항

* **버그 수정**
  * 레벨 진행도 계산 방식을 개선했습니다. 사용자의 현재 점수와 다음 레벨 목표가 현재 레벨을 기준으로 더 정확하게 표시됩니다.
  * 점수 표시가 업데이트되어 일관된 진행 상황을 반영합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->