### PR TITLE
refactor: Mission keyword를 dishId로 변경

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/home/converter/HomeConverter.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/home/converter/HomeConverter.java
@@ -46,7 +46,7 @@ public class HomeConverter {
                 .title(mission.getTitle())
                 .description(mission.getDescription())
                 .reward(mission.getReward())
-                .keyword(mission.getKeyword())
+                .dishId(mission.getDishId())
                 .status(memberMission.getStatus().name())
                 .build();
     }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/home/dto/HomeResponseDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/home/dto/HomeResponseDTO.java
@@ -43,7 +43,7 @@ public class HomeResponseDTO {
         private String title;
         private String description;
         private Integer reward;
-        private String keyword;
+        private Long dishId;
         private String status; // "ASSIGNED", "COMPLETED", "FAILED"
     }
 

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/entity/Mission.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/mission/entity/Mission.java
@@ -26,6 +26,6 @@ public class Mission extends BaseEntity {
     @Column(name = "description", nullable = false, columnDefinition = "TEXT")
     private String description;
 
-    @Column(name = "keyword", nullable = false)
-    private String keyword; // 검색 및 완료 판정 기준 키워드
+    @Column(name = "dish_id", nullable = false)
+    private Long dishId;
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/recipe/repository/RecipeRepository.java
@@ -38,8 +38,6 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     // 조회수(views) 내림차순으로 상위 5개 조회 (HomeService 사용)
     List<Recipe> findTop5ByOrderByViewsDesc();
 
-    boolean existsByIdAndTitleContaining(Long recipeId, String keyword);
-
     // ===== 홈 화면 추천 레시피용 메서드 =====
 
     // 특정 ID 목록에 해당하는 레시피 조회

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/recipe/service/RecipeCommandServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/recipe/service/RecipeCommandServiceImpl.java
@@ -183,7 +183,8 @@ public class RecipeCommandServiceImpl implements RecipeCommandService {
         rewardScore += 5;
 
         // 2. 오늘 미션 매칭 시 완료 보상(예: +20)
-        rewardScore +=  completeTodayMissionIfMatched(memberId, recipeId); // 매칭되면 reward 반환, 아니면 0
+        Long dishId = recipe.getDish() != null ? recipe.getDish().getId() : null;
+        rewardScore += completeTodayMissionIfMatched(memberId, dishId);
 
         if (isFirstCookingToday) {
             //  재료 보너스(하루 1회)
@@ -348,7 +349,7 @@ public class RecipeCommandServiceImpl implements RecipeCommandService {
         }
     }
 
-    private int completeTodayMissionIfMatched(Long memberId, Long recipeId) {
+    private int completeTodayMissionIfMatched(Long memberId, Long dishId) {
         LocalDate today = LocalDate.now();
 
         MemberMission mm = memberMissionRepository
@@ -358,11 +359,10 @@ public class RecipeCommandServiceImpl implements RecipeCommandService {
         if (mm == null) return 0;
         if (mm.getStatus() != MissionStatus.ASSIGNED) return 0;
 
-        String keyword = mm.getMission().getKeyword();
-        if (keyword == null || keyword.isBlank()) return 0;
+        Long missionDishId = mm.getMission().getDishId();
+        if (missionDishId == null || dishId == null) return 0;
 
-        boolean matches = recipeRepository.existsByIdAndTitleContaining(recipeId, keyword);
-        if (!matches) return 0;
+        if (!missionDishId.equals(dishId)) return 0;
 
         mm.completeToday();
 


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- refactor/171-Mission-Dish


## 🔑 주요 변경사항

- Mission 엔터티의 keyword(String)를 dishId(Long)로 변경하여, 요리 완료 시 미션 매칭을 레시피 제목과 문자열 비교에서 dishId 비교로 전환
- 요라완료 메서드에서 dishId 매칭으로 변경


## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **개선 사항**
  * 미션 완료 시스템의 데이터 구조를 업데이트했습니다. API 응답의 미션 정보가 변경되어 더 정확한 요리 추적이 가능해졌습니다.
  * 미션 매칭 검증 로직이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->