### PR TITLE
refactor: 메뉴 검색 API에서 시작하는 단어만 검색되도록 로직 수정

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/recipe/entity/Dish.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/recipe/entity/Dish.java
@@ -9,7 +9,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "dishes")
+@Table(name = "dishes", indexes = @Index(name = "idx_dish_name", columnList = "name"))
 public class Dish extends BaseEntity {
 
     @Id

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/recipe/repository/DishRepository.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/recipe/repository/DishRepository.java
@@ -9,8 +9,20 @@ import org.springframework.data.repository.query.Param;
 
 public interface DishRepository extends JpaRepository<Dish, Long> {
 
-
-    // 주의: 첫 글자만 탐색하기 때문에 DB에 저장된 Dish 이름에 띄어쓰기가 있다면 검색되지 않을 수 있음 (예: DB '제 육 볶음' vs 검색어 '제육')
-    @Query("SELECT d.id as id, d.name as name FROM Dish d WHERE d.name LIKE CONCAT(:keyword, '%')")
-    Page<DishProjection> findProjectedByNameStartingWith(@Param("keyword") String keyword, Pageable pageable);
+    /**
+     * 검색 로직 개선:
+     * 1. 검색어 포함(LIKE %keyword%)하는 모든 결과 조회
+     * 2. 정렬 우선순위:
+     *    - 1순위: 검색어로 시작하는 경우 (CASE WHEN ... THEN 1)
+     *    - 2순위: 그 외 (CASE WHEN ... THEN 2)
+     *    - 3순위: 이름 길이 짧은 순 (LENGTH(d.name))
+     *    - 4순위: 가나다 순 (d.name)
+     */
+    @Query("SELECT d.id as id, d.name as name FROM Dish d " +
+           "WHERE d.name LIKE CONCAT('%', :keyword, '%') " +
+           "ORDER BY " +
+           "CASE WHEN d.name LIKE CONCAT(:keyword, '%') THEN 1 ELSE 2 END, " +
+           "LENGTH(d.name), " +
+           "d.name")
+    Page<DishProjection> findProjectedByNameWeighted(@Param("keyword") String keyword, Pageable pageable);
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈
- refactor/176-search-api-rafactor
- #176 


## 🔑 주요 변경사항
- 검색 로직 개선 (포함 검색 → 접두사 검색)
  - 기존: `LIKE %keyword%` (포함 검색).
  - 변경: LIKE keyword% (접두사 검색).
 
- DB 쿼리 성능 최적화
  - 기존: `WHERE REPLACE(name, ' ', '') LIKE ...`
  - 변경: `WHERE name LIKE ...`
    - 함수 제거를 통해 DB 인덱스를 활용할 수 있도록 쿼리 튜닝 (O(N) → O(log N)).
    
--------[v2]------------
정렬 로직 개선 (Weighted Sorting)
- 검색 범위 확장: LIKE '%keyword%'를 사용하여 검색어를 포함하는 모든 요리를 찾도록 변경.
- 가중치 정렬(Weighted Sorting) 적용: SQL CASE WHEN 구문을 활용하여 결과의 우선순위를 지정.
  -  1순위: 검색어로 시작하는 단어 (예: "김치")
  -  2순위: 검색어를 포함하는 단어 (예: "새우김밥")
  -  3순위: 글자 수가 짧은 순 (정확도 보정)
  -  4순위: 가나다 순

DB 인덱스 추가: Dish 엔티티의 name 컬럼에 인덱스(idx_dish_name) 생성.

## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **기능 개선**
  * 요리 검색 방식을 개선했습니다. 이제 입력한 키워드로 시작하는 요리 이름을 검색합니다.
  * 검색 성능을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->