### PR TITLE
[feat] : 카카오 로그인 이메일 저장 및 계정 설정 조회API 구현

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/controller/MemberController.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/controller/MemberController.java
@@ -79,4 +79,16 @@ public class MemberController {
 
         return ApiResponse.onSuccess(bookmarkedRecipes);
     }
+
+    @GetMapping("/me/account-setting")
+    @Operation(summary = "계정 설정 조회 API", description = "이메일과 로그인 타입을 반환합니다.")
+    public ApiResponse<MemberResponseDTO.AccountSettingDTO> getAccountSetting(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        MemberResponseDTO.AccountSettingDTO response = memberQueryService.getAccountSetting(
+                userDetails.getMember().getId()
+        );
+        return ApiResponse.onSuccess(response);
+    }
 }
+

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/dto/AuthResponseDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/dto/AuthResponseDTO.java
@@ -66,6 +66,7 @@ public class AuthResponseDTO {
         @Getter @NoArgsConstructor
         public static class KakaoAccount {
             private Profile profile;
+            private String email;
         }
 
         @Getter @NoArgsConstructor

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/dto/MemberResponseDTO.java
@@ -1,5 +1,7 @@
 package com.mohaemukzip.mohaemukzip_be.domain.member.dto;
 
+import com.mohaemukzip.mohaemukzip_be.domain.member.entity.enums.LoginType;
+
 import java.util.List;
 
 public class MemberResponseDTO {
@@ -19,4 +21,9 @@ public class MemberResponseDTO {
             String videoDuration,
             Boolean isBookmarked
     ) { }
+
+    public record AccountSettingDTO(
+            String email,
+            LoginType loginType
+    ) {}
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/entity/Member.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/entity/Member.java
@@ -61,6 +61,9 @@ public class Member extends BaseEntity {
     @Column(name = "profile_image_key", length = 500)
     private String profileImageKey;
 
+    @Column(name = "email")
+    private String email;
+
     @Column(name = "fridge_score")
     @Builder.Default
     private Integer fridgeScore = 100;
@@ -93,5 +96,9 @@ public class Member extends BaseEntity {
     public void updateFridgeScore(int delta) {
         if (this.fridgeScore == null) this.fridgeScore = 100;
         this.fridgeScore = Math.max(0, Math.min(100, this.fridgeScore + delta));
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
     }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/auth/AuthCommandServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/auth/AuthCommandServiceImpl.java
@@ -95,7 +95,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             member = memberRepository.findByLoginTypeAndOauthId(LoginType.KAKAO, kakaoId)
                     .orElseGet(() -> {
                         isNewMember.set(true);
-                        return createKakaoMember(kakaoId, nickname);
+                        return createKakaoMember(kakaoId, nickname, kakaoUserInfo.getKakaoAccount().getEmail());
                     });
         } catch (DataIntegrityViolationException e) {
             member = memberRepository.findByLoginTypeAndOauthId(LoginType.KAKAO, kakaoId)
@@ -156,10 +156,11 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         return "카카오 사용자_" + kakaoUserInfo.getId();
     }
 
-    private Member createKakaoMember(String kakaoId, String nickname) {
+    private Member createKakaoMember(String kakaoId, String nickname, String email) {
         Member newMember = Member.builder()
                 .oauthId(kakaoId)
                 .nickname(nickname)
+                .email(email)
                 .loginType(LoginType.KAKAO)
                 .role(Role.ROLE_USER)
                 .score(0)

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/query/member/MemberQueryService.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/query/member/MemberQueryService.java
@@ -9,4 +9,5 @@ public interface MemberQueryService {
     MemberResponseDTO.MyPageDTO getMyPage(Long memberId);
     List<RecipeResponseDTO.RecipePreviewDTO> getRecentlyViewedRecipes(Long memberId);
     RecipeResponseDTO.RecipePreviewListDTO getBookmarkedRecipes(Long memberId, int page);
+    MemberResponseDTO.AccountSettingDTO getAccountSetting(Long memberId);
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/query/member/MemberQueryServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/query/member/MemberQueryServiceImpl.java
@@ -134,5 +134,17 @@ public class MemberQueryServiceImpl implements MemberQueryService {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
+
+    // 이메일 조회
+    @Override
+    public MemberResponseDTO.AccountSettingDTO getAccountSetting(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return new MemberResponseDTO.AccountSettingDTO(
+                member.getEmail(),
+                member.getLoginType()
+        );
+    }
 }
 


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- feat/226-feat-check-kakao-mail


## 🔑 주요 변경사항
- Member 엔티티에 email 컬럼 추가
- 카카오 로그인 시 이메일 추출 후 저장
- 계정 설정 조회 API 추가 (GET /members/me/account-setting)


## Check List
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
