### PR TITLE
[feat]: 냉장고 조회 API 응답에 ingredientId, isFavorite 필드 추가

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/dto/IngredientResponseDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/dto/IngredientResponseDTO.java
@@ -73,6 +73,7 @@ public class IngredientResponseDTO {
     @Builder
     public static class FridgeIngredient {
         private Long memberIngredientId;
+        private Long ingredientId;
         private String name;
         private String storageType;
         private LocalDate expiryDate;
@@ -80,6 +81,7 @@ public class IngredientResponseDTO {
         private String unit;
         private String dDay;
         private String statusColor;
+        private Boolean isFavorite;
 
         // D-day 계산 & 색상 표시
         public static FridgeIngredient from(MemberIngredient entity) {

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/query/IngredientQueryServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/query/IngredientQueryServiceImpl.java
@@ -61,6 +61,9 @@ public class IngredientQueryServiceImpl implements IngredientQueryService {
 
         List<MemberIngredient> memberIngredients = memberIngredientRepository.findAllByMemberId(memberId);
 
+        Set<Long> favoriteIngredientIds = memberFavoriteRepository.findIngredientIdsByMemberId(memberId);
+
+
         List<IngredientResponseDTO.FridgeIngredient> dtoList = memberIngredients.stream()
                 .map(IngredientResponseDTO.FridgeIngredient::from)
                 .collect(toList());


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- feat/232-add-isfavorite-refridge 


## 🔑 주요 변경사항

재료 수정 바텀시트에서 북마크 API 및 소비기한 추천 API 호출 시 필요
냉장고 조회 응답에 ingredientId, isFavorite 필드 추가


## Check List
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* **Chores**
  * 냉장고 재료 조회 응답 데이터 구조 확장
  * 사용자 즐겨찾기 재료 정보 처리 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->