### PR TITLE
[fix]: 냉장고 조회 API 응답에 ingredientId, isFavorite null 반환 버그 수정

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/dto/IngredientResponseDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/dto/IngredientResponseDTO.java
@@ -84,7 +84,7 @@ public class IngredientResponseDTO {
         private Boolean isFavorite;
 
         // D-day 계산 & 색상 표시
-        public static FridgeIngredient from(MemberIngredient entity) {
+        public static FridgeIngredient from(MemberIngredient entity, boolean isFavorite) {
             Ingredient ingredient = entity.getIngredient();
 
             String dDayString = null;
@@ -125,6 +125,8 @@ public class IngredientResponseDTO {
                     .unit(ingredient != null && ingredient.getUnit() != null ? ingredient.getUnit().getLabel() : null)
                     .dDay(dDayString)
                     .statusColor(color)
+                    .ingredientId(ingredient != null ? ingredient.getId() : null)
+                    .isFavorite(isFavorite)
                     .build();
         }
     }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/query/IngredientQueryServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/ingredient/service/query/IngredientQueryServiceImpl.java
@@ -65,7 +65,11 @@ public class IngredientQueryServiceImpl implements IngredientQueryService {
 
 
         List<IngredientResponseDTO.FridgeIngredient> dtoList = memberIngredients.stream()
-                .map(IngredientResponseDTO.FridgeIngredient::from)
+                .map(entity -> {
+                    Long ingredientId = entity.getIngredient() != null ? entity.getIngredient().getId() : null;
+                    boolean isFavorite = ingredientId != null && favoriteIngredientIds.contains(ingredientId);
+                    return IngredientResponseDTO.FridgeIngredient.from(entity, isFavorite);
+                })
                 .collect(toList());
 
         return IngredientResponseDTO.FridgeIngredientList.builder()


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- feat/232-add-isfavorite-refridge 


## 🔑 주요 변경사항

- 냉장고 조회 API 응답에서 ingredientId, isFavorite이 null로 반환되는 문제 수정
- 즐겨찾기 여부 포함 재료검색 API와 동일한 방식으로 데이터 조회하도록 수정


## Check List
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fridge ingredient results now include a favorite status, making it easier to identify saved ingredients at a glance.
  * Ingredient details returned to the app now include a more complete ingredient identifier when available.

* **Bug Fixes**
  * Improved handling of missing ingredient data so fridge ingredient information is built more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->