### PR TITLE
feat: 이메일 인증번호 발송/검증 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.apache.httpcomponents.client5:httpclient5'
 
+
+	//Mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	//jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/controller/AuthController.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/controller/AuthController.java
@@ -140,4 +140,22 @@ public class AuthController {
         AuthResponseDTO.WithdrawalResponse response = authCommandService.withdrawal(memberId);
         return ApiResponse.onSuccess(response);
     }
+
+    @Operation(summary = "이메일 인증번호 발송")
+    @PostMapping("/email/send")
+    public ApiResponse<AuthResponseDTO.SendAuthCodeResponse> sendAuthCode(
+            @Valid @RequestBody AuthRequestDTO.SendAuthCodeRequest request) {
+
+        AuthResponseDTO.SendAuthCodeResponse response = authCommandService.sendAuthCode(request);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(summary = "이메일 인증번호 검증")
+    @PostMapping("/email/verify")
+    public ApiResponse<AuthResponseDTO.VerifyAuthCodeResponse> verifyAuthCode(
+            @Valid @RequestBody AuthRequestDTO.VerifyAuthCodeRequest request) {
+
+        AuthResponseDTO.VerifyAuthCodeResponse response = authCommandService.verifyAuthCode(request);
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/dto/AuthRequestDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/dto/AuthRequestDTO.java
@@ -2,6 +2,7 @@ package com.mohaemukzip.mohaemukzip_be.domain.member.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
@@ -70,5 +71,23 @@ public class AuthRequestDTO {
             @Schema(description = "애플 identity token")
             @NotBlank(message = "애플 identity token은 필수입니다.")
             String identityToken
+    ) {}
+
+    public record SendAuthCodeRequest(
+            @Schema(description = "이메일", example = "test@naver.com")
+            @NotBlank(message = "이메일을 입력해주세요.")
+            @Email(message = "이메일 형식이 아닙니다.")
+            String email
+    ) {}
+
+    public record VerifyAuthCodeRequest(
+            @Schema(description = "이메일", example = "test@naver.com")
+            @NotBlank(message = "이메일을 입력해주세요.")
+            @Email(message = "이메일 형식이 아닙니다.")
+            String email,
+
+            @Schema(description = "인증번호", example = "123456")
+            @NotBlank(message = "인증번호를 입력해주세요.")
+            String authCode
     ) {}
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/dto/AuthRequestDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/dto/AuthRequestDTO.java
@@ -88,6 +88,7 @@ public class AuthRequestDTO {
 
             @Schema(description = "인증번호", example = "123456")
             @NotBlank(message = "인증번호를 입력해주세요.")
+            @Pattern(regexp = "^\\d{6}$", message = "인증번호는 6자리 숫자입니다.")
             String authCode
     ) {}
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/dto/AuthResponseDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/dto/AuthResponseDTO.java
@@ -58,6 +58,15 @@ public class AuthResponseDTO {
             String message
     ) { }
 
+    public record SendAuthCodeResponse(
+            String message
+    ) {}
+
+    public record VerifyAuthCodeResponse(
+            boolean verified,
+            String message
+    ) {}
+
     @Getter
     @NoArgsConstructor
     public static class GetKakaoUserInfoDTO {

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/entity/Member.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/entity/Member.java
@@ -23,6 +23,10 @@ import java.time.LocalDate;
                 @UniqueConstraint(
                         name = "uk_provider_oauth_id",
                         columnNames = {"login_type", "oauth_id"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_member_email",
+                        columnNames = {"email"}
                 )
         }
 )

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/entity/Member.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/entity/Member.java
@@ -61,6 +61,9 @@ public class Member extends BaseEntity {
     @Column(name = "profile_image_key", length = 500)
     private String profileImageKey;
 
+    @Column(name = "email")
+    private String email;
+
     @Column(name = "fridge_score")
     @Builder.Default
     private Integer fridgeScore = 100;
@@ -93,5 +96,9 @@ public class Member extends BaseEntity {
     public void updateFridgeScore(int delta) {
         if (this.fridgeScore == null) this.fridgeScore = 100;
         this.fridgeScore = Math.max(0, Math.min(100, this.fridgeScore + delta));
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
     }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/repository/MemberRepository.java
@@ -17,8 +17,9 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     Boolean existsByOauthId(String oauthId);
     Optional<Member> findByLoginId(String loginId);
     Boolean existsByLoginId(String loginId);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE) // 동시성 방지용 (같은 사용자가 2번 complete 호출 경우)
+    Boolean existsByEmail(String email);
+    Optional<Member> findByEmail(String email);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select m from Member m where m.id = :memberId")
     Optional<Member> findByIdForUpdate(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/auth/AuthCommandService.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/auth/AuthCommandService.java
@@ -11,4 +11,6 @@ public interface AuthCommandService {
     AuthResponseDTO.TokenResponse reissueToken(String refreshToken);
     AuthResponseDTO.LogoutResponse logout(String accessToken);
     AuthResponseDTO.WithdrawalResponse withdrawal(Long memberId);
+    AuthResponseDTO.SendAuthCodeResponse sendAuthCode(AuthRequestDTO.SendAuthCodeRequest request);
+    AuthResponseDTO.VerifyAuthCodeResponse verifyAuthCode(AuthRequestDTO.VerifyAuthCodeRequest request);
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/auth/AuthCommandServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/auth/AuthCommandServiceImpl.java
@@ -269,7 +269,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         return AuthConverter.toWithdrawalResponseDTO();
     }
 
-    @Transactional
+
     public AuthResponseDTO.SendAuthCodeResponse sendAuthCode(AuthRequestDTO.SendAuthCodeRequest request) {
         // 이메일 중복 확인
         if (memberRepository.existsByEmail(request.email())) {

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/auth/AuthCommandServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/auth/AuthCommandServiceImpl.java
@@ -13,6 +13,7 @@ import com.mohaemukzip.mohaemukzip_be.global.jwt.JwtProvider;
 import com.mohaemukzip.mohaemukzip_be.global.jwt.TokenBlacklistService;
 import com.mohaemukzip.mohaemukzip_be.global.response.code.status.ErrorStatus;
 import com.mohaemukzip.mohaemukzip_be.global.service.ApplePublicKeyService;
+import com.mohaemukzip.mohaemukzip_be.global.service.EmailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -41,6 +42,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
     private final WebClient webClient;
     private final TokenBlacklistService tokenBlacklistService;
     private final ApplePublicKeyService applePublicKeyService;
+    private final EmailService emailService;
 
     private static final String KAKAO_USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
     private static final String REFRESH_TOKEN_PREFIX = "RT:";
@@ -265,6 +267,28 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         redisTemplate.delete(REFRESH_TOKEN_PREFIX + memberId);
 
         return AuthConverter.toWithdrawalResponseDTO();
+    }
+
+    @Transactional
+    public AuthResponseDTO.SendAuthCodeResponse sendAuthCode(AuthRequestDTO.SendAuthCodeRequest request) {
+        // 이메일 중복 확인
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new BusinessException(ErrorStatus.DUPLICATE_EMAIL);
+        }
+
+        emailService.sendAuthCode(request.email());
+
+        return new AuthResponseDTO.SendAuthCodeResponse("인증번호가 발송되었습니다.");
+    }
+
+    public AuthResponseDTO.VerifyAuthCodeResponse verifyAuthCode(AuthRequestDTO.VerifyAuthCodeRequest request) {
+        boolean verified = emailService.verifyAuthCode(request.email(), request.authCode());
+
+        if (!verified) {
+            return new AuthResponseDTO.VerifyAuthCodeResponse(false, "인증번호가 일치하지 않거나 만료되었습니다.");
+        }
+
+        return new AuthResponseDTO.VerifyAuthCodeResponse(true, "인증이 완료되었습니다.");
     }
 
     private AuthResponseDTO.GetKakaoUserInfoDTO getKakaoUserInfo(String accessToken) {

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/response/code/status/ErrorStatus.java
@@ -22,6 +22,8 @@ public enum ErrorStatus implements BaseCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4004", "유효하지 않은 토큰입니다."),
     REFRESH_TOKEN_MISMATCH(HttpStatus.FORBIDDEN, "AUTH4005", "Refresh Token이 일치하지 않습니다."),
     DUPLICATE_LOGIN_ID(HttpStatus.BAD_REQUEST, "AUTH4006", "중복된 로그인 아이디입니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "AUTH4015", "이미 사용 중인 이메일입니다."),
+    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "AUTH4016", "인증번호가 일치하지 않거나 만료되었습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH4007", "비밀번호가 올바르지 않습니다."),
     MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4008", "토큰의 형식이 올바르지 않습니다."),
     INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "AUTH4009", "토큰의 서명이 올바르지 않습니다."),

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/service/EmailService.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/service/EmailService.java
@@ -1,0 +1,59 @@
+package com.mohaemukzip.mohaemukzip_be.global.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String EMAIL_AUTH_PREFIX = "EMAIL_AUTH:";
+    private static final long EMAIL_AUTH_TTL = 5;
+
+    public void sendAuthCode(String email) {
+        String authCode = generateAuthCode();
+
+        // Redis에 저장 (TTL 5분)
+        redisTemplate.opsForValue().set(
+                EMAIL_AUTH_PREFIX + email,
+                authCode,
+                EMAIL_AUTH_TTL,
+                TimeUnit.MINUTES
+        );
+
+        // 메일 발송
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("[뭐해먹집] 이메일 인증번호");
+        message.setText("인증번호: " + authCode + "\n\n5분 안에 입력해주세요.");
+        mailSender.send(message);
+
+        log.info("인증번호 발송 완료 - email: {}", email);
+    }
+
+    public boolean verifyAuthCode(String email, String inputCode) {
+        String storedCode = redisTemplate.opsForValue().get(EMAIL_AUTH_PREFIX + email);
+
+        if (storedCode == null) {
+            return false; // 만료
+        }
+
+        return storedCode.equals(inputCode);
+    }
+
+    private String generateAuthCode() {
+        Random random = new Random();
+        return String.format("%06d", random.nextInt(1000000));
+    }
+}

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/service/EmailService.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/service/EmailService.java
@@ -7,7 +7,7 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
-import java.util.Random;
+import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class EmailService {
 
+    private final SecureRandom secureRandom = new SecureRandom();
     private final JavaMailSender mailSender;
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -49,11 +50,14 @@ public class EmailService {
             return false; // 만료
         }
 
-        return storedCode.equals(inputCode);
+        boolean matched = storedCode.equals(inputCode);
+        if (matched) {
+            redisTemplate.delete(EMAIL_AUTH_PREFIX + email);
+        }
+        return matched;
     }
 
     private String generateAuthCode() {
-        Random random = new Random();
-        return String.format("%06d", random.nextInt(1000000));
+        return String.format("%06d", secureRandom.nextInt(1000000));
     }
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- feat/223-send-email-verification 


## 🔑 주요 변경사항
- build.gradle에 Gmail SMTP 의존성 추가
- Member 엔티티에 email 컬럼 추가
- 카카오 로그인 시 이메일 추출 후 저장
- 이메일 인증번호 발송 API 추가 (POST /auth/email/send)
- 이메일 인증번호 검증 API 추가 (POST /auth/email/verify)

<img width="1179" height="981" alt="image" src="https://github.com/user-attachments/assets/9ed37895-8f8d-4052-be43-e6294a36cc24" />


## Check List
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 이메일로 인증번호를 발송하고, 입력한 인증번호를 검증하는 API를 추가했습니다.  
  * 이메일 형식/인증번호(6자리) 유효성 검증을 지원하며, 인증 응답 정보를 제공합니다.  
  * 회원 이메일 필드와 이메일 중복 방지를 위한 제약을 추가했습니다.  
* **버그 수정**
  * 중복 이메일로 인증 요청 시 명확한 오류를 반환하도록 개선했습니다.  
  * 만료되었거나 일치하지 않는 인증번호에 대해 실패 응답을 제공하도록 했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->