### PR TITLE
feat: 회원가입 - loginId를 이메일 형식으로 변경

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/dto/AuthRequestDTO.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/dto/AuthRequestDTO.java
@@ -2,6 +2,7 @@ package com.mohaemukzip.mohaemukzip_be.domain.member.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
@@ -11,11 +12,11 @@ import java.util.List;
 public class AuthRequestDTO {
     @Schema(description = "로그인 요청")
     public record LoginRequest(
-            @Schema(description = "로그인 ID", example = "admin")
+            @Schema(description = "로그인 ID", example = "test@naver.com")
             @NotBlank
             String loginId,
 
-            @Schema(description = "비밀번호", example = "mohaemukzip123!")
+            @Schema(description = "비밀번호", example = "Test1234!")
             @NotBlank
             String password
     ) { }
@@ -26,9 +27,9 @@ public class AuthRequestDTO {
             @NotBlank(message = "닉네임은 필수입니다")
             String nickname,
 
-            @Schema(description = "로그인 ID", example = "test01")
-            @NotBlank(message = "아이디는 필수입니다")
-            @Pattern(regexp = "^(?=.*[A-Za-z])[A-Za-z\\d]{4,20}$", message = "아이디는 영문과 숫자를 사용해 4자 이상 입력해주세요.")
+            @Schema(description = "이메일", example = "test@naver.com")
+            @NotBlank(message = "이메일은 필수입니다.")
+            @Email(message = "이메일 형식이 아닙니다.")
             String loginId,
 
             @Schema(description = "비밀번호", example = "Test1234!")
@@ -53,10 +54,9 @@ public class AuthRequestDTO {
     ) { }
 
     public record CheckLoginIdRequest(
-            @Schema(description = "아이디", example = "test01")
-            @NotBlank(message = "아이디를 입력해주세요.")
-            @Pattern(regexp = "^(?=.*[A-Za-z])[A-Za-z\\d]{4,20}$",
-                    message = "아이디는 영문, 숫자 4-20자로 입력해주세요.")
+            @Schema(description = "이메일", example = "test@naver.com")
+            @NotBlank(message = "이메일을 입력해주세요.")
+            @Email(message = "이메일 형식이 아닙니다.")
             String loginId
     ) {}
 


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- feat/221-change-loginId-to-mail 


## 🔑 주요 변경사항

-  일반 로그인 회원가입 시 loginId를 이메일 형식으로 변경합니다. 기존 영문+숫자 아이디 방식에서 이메일 형식으로 전환합니다.


## Check List
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!
