### PR TITLE
feat: Add Prometheus custom metrics and Micrometer Tracing for Gemini…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,10 +64,16 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	//monitoring
+	//monitoring & tracing
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+
+	//resilience4j
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
 
 	//apple
 	implementation 'com.nimbusds:nimbus-jose-jwt:10.0.2'

--- a/compose.monitoring.dev.yaml
+++ b/compose.monitoring.dev.yaml
@@ -56,6 +56,19 @@ services:
       - REDIS_ADDR=redis://host.docker.internal:6379
     restart: unless-stopped
 
+  tempo:
+    image: grafana/tempo:latest
+    container_name: tempo-mohaemukzip-dev
+    user: root
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./monitoring/tempo.yaml:/etc/tempo.yaml:ro
+      - tempo-data-dev:/tmp/tempo
+    ports:
+      - "9411:9411"  # zipkin port
+    restart: unless-stopped
+
 volumes:
   prometheus-data-dev:
   grafana-data-dev:
+  tempo-data-dev:

--- a/compose.monitoring.prod.yaml
+++ b/compose.monitoring.prod.yaml
@@ -65,6 +65,20 @@ services:
       - mohaemukzip-api_spring-network
     restart: unless-stopped
 
+  tempo:
+    image: grafana/tempo:latest
+    container_name: tempo-mohaemukzip-prod
+    user: root
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./monitoring/tempo.yaml:/etc/tempo.yaml:ro
+      - tempo-data:/tmp/tempo
+    ports:
+      - "127.0.0.1:9411:9411"  # zipkin port
+    networks:
+      - mohaemukzip-api_spring-network
+    restart: unless-stopped
+
 networks:
   mohaemukzip-api_spring-network:
     external: true
@@ -72,3 +86,4 @@ networks:
 volumes:
   prometheus-data:
   grafana-data:
+  tempo-data:

--- a/monitoring/prometheus-prod.yaml
+++ b/monitoring/prometheus-prod.yaml
@@ -4,7 +4,9 @@ global:
 scrape_configs:
   - job_name: 'mohaemukzip-api'
     static_configs:
-      - targets: ['mohaemukzip-api:8080']
+      - targets: ['mohaemukzip-api:9091']
+        labels:
+          application: 'mohaemukzip_BE'
     metrics_path: '/actuator/prometheus'
 
   - job_name: 'node-exporter'

--- a/monitoring/provisioning/datasources/grafana-datasources-dev.yaml
+++ b/monitoring/provisioning/datasources/grafana-datasources-dev.yaml
@@ -7,3 +7,9 @@ datasources:
     url: http://prometheus-mohaemukzip-dev:9090
     isDefault: true
     editable: true
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo-mohaemukzip-dev:3200
+    uid: tempo

--- a/monitoring/provisioning/datasources/grafana-datasources-prod.yaml
+++ b/monitoring/provisioning/datasources/grafana-datasources-prod.yaml
@@ -7,3 +7,9 @@ datasources:
     url: http://prometheus-mohaemukzip-prod:9090
     isDefault: true
     editable: false
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo-mohaemukzip-prod:3200
+    uid: tempo

--- a/monitoring/tempo.yaml
+++ b/monitoring/tempo.yaml
@@ -1,0 +1,15 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    zipkin:
+      endpoint: 0.0.0.0:9411
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks
+    wal:
+      path: /tmp/tempo/wal

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/chatbot/service/external/GeminiService.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/chatbot/service/external/GeminiService.java
@@ -11,6 +11,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.micrometer.core.instrument.MeterRegistry;
 
 import java.time.Duration;
 import java.util.List;
@@ -25,6 +27,7 @@ public class GeminiService {
 
     private final WebClient geminiWebClient;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
 
     @Value("${gemini.recipe.api-url}")
     private String apiUrl;
@@ -33,11 +36,14 @@ public class GeminiService {
 
     public GeminiService(
             @Qualifier("geminiRecipeWebClient") WebClient geminiWebClient,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            MeterRegistry meterRegistry) {
         this.geminiWebClient = geminiWebClient;
         this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistry;
     }
 
+    @CircuitBreaker(name = "gemini", fallbackMethod = "fallbackGenerateChatResponse")
     public String generateChatResponse(Long memberId, String systemPrompt, List<GeminiRequestDTO.Content> contents) {
         GeminiRequestDTO request = GeminiRequestDTO.builder()
                 .systemInstruction(GeminiRequestDTO.SystemInstruction.builder()
@@ -96,6 +102,8 @@ public class GeminiService {
                             int completionTokens = response.getUsageMetadata().getCandidatesTokenCount();
                             chatbotMonitorLog.info("{\"action\": \"CHATBOT_USAGE\", \"memberId\": {}, \"promptTokens\": {}, \"completionTokens\": {}, \"totalTokens\": {}, \"status\": \"SUCCESS\"}",
                                     memberId, promptTokens, completionTokens, totalTokens);
+                                    
+                            meterRegistry.counter("gemini_api_tokens_total", "model", MODEL_NAME).increment(totalTokens);
                         }
                         
                         return text;
@@ -109,5 +117,10 @@ public class GeminiService {
             return null;
         }
         return null;
+    }
+
+    public String fallbackGenerateChatResponse(Long memberId, String systemPrompt, List<GeminiRequestDTO.Content> contents, Throwable t) {
+        log.error("Gemini API 서킷 브레이커 발동! Fallback 실행 - 원인: {}", t.getMessage());
+        throw new RuntimeException("현재 AI 서비스가 지연되고 있습니다. 잠시 후 다시 시도해주세요.");
     }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/client/transcript/RapidApiTranscriptClient.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/client/transcript/RapidApiTranscriptClient.java
@@ -11,7 +11,11 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.http.ResponseEntity;
 import reactor.core.publisher.Mono;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import java.time.Duration;
 import java.util.List;
@@ -21,36 +25,57 @@ import java.util.List;
 public class RapidApiTranscriptClient implements TranscriptClient {
 
     private final WebClient webClient;
+    private final MeterRegistry meterRegistry;
+    private final AtomicInteger rapidApiRemaining = new AtomicInteger(0);
 
-    public RapidApiTranscriptClient(@Qualifier("rapidApiWebClient") WebClient webClient) {
+    public RapidApiTranscriptClient(@Qualifier("rapidApiWebClient") WebClient webClient, MeterRegistry meterRegistry) {
         this.webClient = webClient;
+        this.meterRegistry = meterRegistry;
+        this.meterRegistry.gauge("rapidapi_requests_remaining", rapidApiRemaining);
     }
 
     @Override
+    @CircuitBreaker(name = "rapidapi", fallbackMethod = "fallbackFetchTranscript")
     public List<TranscriptSegment> fetchTranscript(String videoId) {
         log.info("RapidAPI 자막 조회 시작 - videoId: {}", videoId);
 
-        // 책임 1+2: HTTP 호출 및 상태코드 → 예외 변환을 reactive chain 내에서 처리
-        RapidApiTranscriptResponse response = webClient.get()
+        ResponseEntity<RapidApiTranscriptResponse> responseEntity = webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/api/transcript")
                         .queryParam("videoId", videoId)
-                        .queryParam("lang", "ko") // 한국어 요청 복구
+                        .queryParam("lang", "ko")
                         .build())
                 .retrieve()
                 .onStatus(this::isAuthOrEndpointError, this::handleAuthOrEndpointError)
                 .onStatus(HttpStatusCode::isError, this::handleGenericHttpError)
-                .bodyToMono(RapidApiTranscriptResponse.class)
-                // BusinessException은 그대로 전파, 나머지는 INTERNAL_SERVER_ERROR로 변환
+                .toEntity(RapidApiTranscriptResponse.class)
                 .onErrorMap(e -> !(e instanceof BusinessException),
                         e -> {
+                            meterRegistry.counter("rapidapi_requests_total", "status", "error").increment();
                             log.error("자막 추출 중 예기치 못한 오류 - videoId: {}", videoId, e);
                             return new BusinessException(ErrorStatus.INTERNAL_SERVER_ERROR);
                         })
-                .block(Duration.ofSeconds(12)); // HttpClient responseTimeout보다 약간 크게 설정하여 경합 조건 방지
+                .block(Duration.ofSeconds(12));
 
-        // 책임 3: 응답 데이터 검증
-        return validateTranscript(response, videoId);
+        meterRegistry.counter("rapidapi_requests_total", "status", "success").increment();
+
+        if (responseEntity != null && responseEntity.getHeaders().containsKey("X-RateLimit-Requests-Remaining")) {
+            try {
+                String remainingStr = responseEntity.getHeaders().getFirst("X-RateLimit-Requests-Remaining");
+                if (remainingStr != null) {
+                    rapidApiRemaining.set(Integer.parseInt(remainingStr));
+                }
+            } catch (NumberFormatException e) {
+                log.warn("Failed to parse X-RateLimit-Requests-Remaining header", e);
+            }
+        }
+
+        return validateTranscript(responseEntity != null ? responseEntity.getBody() : null, videoId);
+    }
+
+    public List<TranscriptSegment> fallbackFetchTranscript(String videoId, Throwable t) {
+        log.error("RapidAPI 서킷 브레이커 발동! Fallback 실행 - videoId: {}, 원인: {}", videoId, t.getMessage());
+        throw new RuntimeException("현재 AI 자막 추출 서비스가 지연되고 있습니다. 잠시 후 다시 시도해주세요.");
     }
 
     // HTTP 상태코드 분류 (책임 2 보조)

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/config/GeminiConfig.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/config/GeminiConfig.java
@@ -33,21 +33,21 @@ public class GeminiConfig {
     private int responseTimeout;
 
     @Bean(name = "geminiRecipeWebClient")
-    public WebClient geminiRecipeWebClient() {
-        return createWebClient(recipeApiUrl, recipeApiKey);
+    public WebClient geminiRecipeWebClient(WebClient.Builder builder) {
+        return createWebClient(builder, recipeApiUrl, recipeApiKey);
     }
 
     @Bean(name = "geminiSummaryWebClient")
-    public WebClient geminiSummaryWebClient() {
-        return createWebClient(summaryApiUrl, summaryApiKey);
+    public WebClient geminiSummaryWebClient(WebClient.Builder builder) {
+        return createWebClient(builder, summaryApiUrl, summaryApiKey);
     }
 
-    private WebClient createWebClient(String baseUrl, String apiKey) {
+    private WebClient createWebClient(WebClient.Builder builder, String baseUrl, String apiKey) {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeout * 1000)
                 .responseTimeout(Duration.ofSeconds(responseTimeout));
 
-        return WebClient.builder()
+        return builder
                 .baseUrl(baseUrl)
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
             "/actuator/health",
             "/actuator/prometheus",
             "/auth/email/send",
-            "/auth/email/verify"
+            "/auth/email/verify",
+            "/api/diagnostic/trace"
     };
 
     @Bean

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/config/YouTubeConfig.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/config/YouTubeConfig.java
@@ -14,8 +14,8 @@ public class YouTubeConfig {
     private String baseUrl;
 
     @Bean(name = "youtubeWebClient")
-    public WebClient youtubeWebClient() {
-        return WebClient.builder()
+    public WebClient youtubeWebClient(WebClient.Builder builder) {
+        return builder
                 .baseUrl(baseUrl)
                 .defaultHeader("Accept", "application/json")
                 .build();

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/exception/GlobalExceptionHandler.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -232,5 +233,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.onFailure(ErrorStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    @ExceptionHandler(CallNotPermittedException.class)
+    public ResponseEntity<ApiResponse<Object>> handleCircuitBreakerException(CallNotPermittedException ex) {
+        log.error("CircuitBreaker is OPEN: {}", ex.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(ApiResponse.onFailure(ErrorStatus.SERVICE_UNAVAILABLE, ErrorStatus.SERVICE_UNAVAILABLE.getMessage()));
     }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/response/code/status/ErrorStatus.java
@@ -84,6 +84,7 @@ public enum ErrorStatus implements BaseCode {
     GEMINI_BAD_REQUEST(HttpStatus.BAD_REQUEST, "GEMINI4001", "잘못된 Gemini 요청입니다."),
     GEMINI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GEMINI5001", "Gemini 서버 오류입니다."),
     EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL5001", "외부 API 호출 중 오류가 발생했습니다."),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "COMMON503", "현재 외부 AI 서버가 불안정하여 서비스를 이용할 수 없습니다. 잠시 후 다시 시도해 주세요."),
     SUMMARY_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "GEMINI5002", "요약문 생성에 실패했습니다."),
     // 미션 관련 에러
     NO_AVAILABLE_MISSION(HttpStatus.NOT_FOUND, "MISSION4001", "퀘스트로 할당할 미션이 남아있지 않습니다.")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,13 @@ spring:
     # include: openai  <-- 제거 (통합하므로 불필요)
 
 management:
+  tracing:
+    enabled: true
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: ${TEMPO_URL:http://localhost:9411/api/v2/spans}
   endpoints:
     web:
       base-path: /actuator         # /actuator/prometheus
@@ -46,3 +53,16 @@ gemini:
 youtube:
   api:
     base-url: https://www.googleapis.com/youtube/v3
+
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        registerHealthIndicator: true
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 5
+        permittedNumberOfCallsInHalfOpenState: 3
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        waitDurationInOpenState: 10s
+        failureRateThreshold: 50
+        eventConsumerBufferSize: 10


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- **Branch:** `254-feat-gemini-repid-api-monitoring`
- **Issue:** 외부 의존성(Gemini, RapidAPI) 장애 격리를 위한 서킷 브레이커 도입 및 관측성(Prometheus, Grafana Tempo) 인프라 구축


## 🔑 주요 변경사항

이번 PR은 단순한 기능 구현을 넘어, AI 및 외부 API에 강하게 의존하는 우리 서비스의 **안정성(Resilience)**과 **관측성(Observability)**을 대폭 향상시키는 인프라 레벨의 핵심 아키텍처 개선입니다.

**1. 🛡️ Resilience4j를 통한 외부 API 장애 격리 (Circuit Breaker)**
- `GeminiService` 및 `RapidApiTranscriptClient`에 `@CircuitBreaker`를 전면 적용했습니다.
- 이제 구글 Gemini 서버나 RapidAPI 자막 추출 서버에 타임아웃이나 장애(500 Error)가 발생하더라도, 모해먹집 서버의 스레드가 고갈되어 동반 다운되는 **연쇄 장애(Cascading Failure)를 완벽하게 차단**합니다.
- 장애 발생 시 즉각적으로 Fallback 메서드로 전환되어 사용자에게 안전한 안내 메시지를 반환합니다.

**2. 📊 비즈니스 커스텀 메트릭 수집 (Prometheus)**
- **Gemini 토큰 과금 방어:** `gemini_api_tokens_total` (Counter) 메트릭을 추가하여, AI가 소모하는 프롬프트 및 응답 토큰의 누적 사용량을 모니터링합니다.
- **API 할당량 초과 방지:** `rapidapi_requests_remaining` (Gauge) 메트릭을 추가하여, 외부 API 통신 응답 헤더에 담긴 남은 호출 횟수(Quota)를 실시간으로 스크랩(Scraping)합니다. 이를 통해 월간 무료 횟수 소진 전 알림(Alert)을 구축할 수 있는 기반을 마련했습니다.

**3. 🔍 Micrometer + Grafana Tempo 분산 추적(Distributed Tracing) 도입**
- 단일 요청에 대해 **Trace ID**를 부여하고, 스프링 `WebClient`를 통한 외부 API 통신마다 하위 **Span**을 자동 생성합니다.
- Grafana Tempo 화면을 통해 `/recipes` API 호출 시 **RapidAPI 대기 시간(약 0.1초)과 Gemini 응답 대기 시간(약 7초)**을 폭포수(Waterfall) 그래프로 명확히 시각화하여 팩트 기반의 성능 최적화(Bottleneck) 타겟팅이 가능해졌습니다.

---

### 🗺️ 모니터링 및 장애 격리 아키텍처 흐름도

```mermaid
sequenceDiagram
    autonumber
    participant Client as 클라이언트
    participant Spring as 모해먹집 서버 (Spring Boot)
    participant Resilience as 서킷 브레이커
    participant External as 외부 서버 (Gemini / RapidAPI)
    participant Tempo as Grafana Tempo
    participant Prometheus as Prometheus

    Client->>Spring: POST /recipes (자막 요약 요청)
    activate Spring
    Note over Spring: [Trace ID 발급] 분산 추적 시작

    Spring->>Resilience: WebClient 외부 API 호출 요청
    activate Resilience
    
    alt 정상 상태 (Closed)
        Resilience->>External: API 호출 수행
        External-->>Resilience: 결과 반환 (200 OK)
        Note over Spring,Prometheus: [메트릭 갱신] 토큰 사용량 / 남은 할당량 기록
    else 장애/지연 상태 (Open)
        Note over Resilience,External: 지속적 타임아웃/에러 시 외부 호출 즉시 차단
        Resilience-->>Spring: Fallback 로직 반환 (안전한 예외 처리)
    end
    deactivate Resilience

    Spring-->>Client: 최종 레시피 데이터 또는 에러 응답
    deactivate Spring

    Note over Spring,Tempo: [비동기 전송] 완료된 트레이스 데이터(걸린 시간, 성공 여부 등) 전송
    
    loop 15초 단위 주기적 수집
        Prometheus->>Spring: GET /actuator/prometheus
        Spring-->>Prometheus: 누적된 커스텀 메트릭 전달
    end
```


## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 외부 AI 요청에 대한 추적과 모니터링이 추가되어, 서비스 상태를 더 쉽게 확인할 수 있게 되었습니다.
  * Grafana에서 분산 추적 데이터를 볼 수 있도록 Tempo 연동이 추가되었습니다.

* **Bug Fixes**
  * 외부 AI/트랜스크립트 호출 실패 시 더 안정적으로 처리되며, 과부하 상황에서는 자동으로 대체 응답을 제공합니다.
  * 공개 진단 경로가 추가되어 문제 확인이 더 쉬워졌습니다.

* **Chores**
  * 모니터링 환경과 프로덕션 환경 구성이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->