### PR TITLE
feat: 카카오 로그인 신규회원 약관동의 강제 처리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.apache.httpcomponents.client5:httpclient5'
 
-
 	//Mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	//jwt

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/controller/AuthController.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.mohaemukzip.mohaemukzip_be.domain.member.controller;
 
 import com.mohaemukzip.mohaemukzip_be.domain.member.dto.AuthResponseDTO;
 import com.mohaemukzip.mohaemukzip_be.domain.member.dto.AuthRequestDTO;
+import com.mohaemukzip.mohaemukzip_be.domain.member.dto.TermRequestDTO;
 import com.mohaemukzip.mohaemukzip_be.domain.member.dto.TermResponseDTO;
 import com.mohaemukzip.mohaemukzip_be.domain.member.service.command.auth.AuthCommandService;
 import com.mohaemukzip.mohaemukzip_be.domain.member.service.query.auth.AuthQueryService;
@@ -19,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -100,25 +103,25 @@ public class AuthController {
         return ApiResponse.onSuccess(response);
     }
 
-//    @Operation(summary = "소셜로그인 후 약관 동의",
-//            description = "[\n" +
-//                    " { \"termId\": 1, \"isAgreed\": true },\n" +
-//                    " { \"termId\": 2, \"isAgreed\": true },\n" +
-//                    " { \"termId\": 3, \"isAgreed\": true },\n" +
-//                    " { \"termId\": 4, \"isAgreed\": false }\n" +
-//                    " ]")
-//
-//    @PostMapping("/terms/agree")
-//    public ApiResponse<Void> agreeTermsAfterSocialLogin(
-//            @AuthenticationPrincipal CustomUserDetails userDetails,
-//            @Valid @RequestBody List<TermRequestDTO.TermAgreementRequest> terms) {
-//        if (userDetails == null) {
-//            throw new BusinessException(ErrorStatus.TOKEN_MISSING);
-//        }
-//        Long memberId = userDetails.getMember().getId();
-//        termCommandService.updateMemberTerms(memberId, terms);
-//        return ApiResponse.onSuccess(null);
-//    }
+    @Operation(summary = "소셜로그인 후 약관 동의",
+            description = "[\n" +
+                    " { \"termId\": 1, \"isAgreed\": true },\n" +
+                    " { \"termId\": 2, \"isAgreed\": true },\n" +
+                    " { \"termId\": 3, \"isAgreed\": true },\n" +
+                    " { \"termId\": 4, \"isAgreed\": false }\n" +
+                    " ]")
+
+    @PostMapping("/terms/agree")
+    public ApiResponse<Void> agreeTermsAfterSocialLogin(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody List<TermRequestDTO.TermAgreementRequest> terms) {
+        if (userDetails == null) {
+            throw new BusinessException(ErrorStatus.TOKEN_MISSING);
+        }
+        Long memberId = userDetails.getMember().getId();
+        termCommandService.updateMemberTerms(memberId, terms);
+        return ApiResponse.onSuccess(null);
+    }
 
     @Operation(summary = "로그아웃")
     @PostMapping("/logout")

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/entity/Member.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/entity/Member.java
@@ -72,6 +72,10 @@ public class Member extends BaseEntity {
     @Builder.Default
     private Integer fridgeScore = 100;
 
+    @Column(name = "terms_agreed", nullable = false)
+    @Builder.Default
+    private Boolean termsAgreed = false;
+
     public void deactivate() {
         if (this.inactiveDate == null) {
             this.inactiveDate = LocalDate.now();
@@ -108,5 +112,9 @@ public class Member extends BaseEntity {
 
     public void updatePassword(String password) {
         this.password = password;
+    }
+
+    public void agreeToTerms() {
+        this.termsAgreed = true;
     }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/auth/AuthCommandServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/auth/AuthCommandServiceImpl.java
@@ -65,6 +65,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
                 .build();
         Member savedMember = memberRepository.save(member);
         termCommandService.createMemberTerms(savedMember, request.termAgreements());
+        savedMember.agreeToTerms();
 
         return generateAndSaveTokens(member, true);
     }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/term/TermCommandServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/term/TermCommandServiceImpl.java
@@ -66,6 +66,7 @@ public class TermCommandServiceImpl implements TermCommandService {
         memberTermRepository.deleteAllByMember(member);
         // createMemberTerms 재사용 (termName, agreedAt 완벽)
         createMemberTerms(member, terms);
+        member.agreeToTerms();
     }
 
     /**

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/config/SecurityConfig.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/config/SecurityConfig.java
@@ -68,10 +68,10 @@ public class SecurityConfig {
                 .requestMatchers( PUBLIC_ENDPOINTS).permitAll()
                 .anyRequest().authenticated()
             )
-            .addFilterBefore(
-                new JwtAuthenticationFilter(jwtProvider, tokenBlacklistChecker),
-                UsernamePasswordAuthenticationFilter.class
-            );
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtProvider, tokenBlacklistChecker, jwtAccessDeniedHandler),
+                        UsernamePasswordAuthenticationFilter.class
+                );
 
         return http.build();
     }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,8 @@
 package com.mohaemukzip.mohaemukzip_be.global.jwt;
 
 import com.mohaemukzip.mohaemukzip_be.global.security.CustomUserDetails;
+import com.mohaemukzip.mohaemukzip_be.global.security.JwtAccessDeniedHandler;
+import com.mohaemukzip.mohaemukzip_be.global.security.TermsAgreementRequiredException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,11 +14,20 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Set;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
     private final TokenBlacklistChecker tokenBlacklistChecker;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    private static final Set<String> TERMS_WHITELIST = Set.of(
+            "/auth/terms/agree",
+            "/auth/terms",
+            "/auth/logout",
+            "/auth/withdrawal"
+    );
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -48,6 +59,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         if (userDetails.getMember().isInactive()) {
                             SecurityContextHolder.clearContext();
                             filterChain.doFilter(request, response);
+                            return;
+                        }
+
+                        // 약관동의 미완료 회원 - 화이트리스트 경로 아니면 차단
+                        if (!Boolean.TRUE.equals(userDetails.getMember().getTermsAgreed())
+                                && !TERMS_WHITELIST.contains(request.getRequestURI())) {
+                            jwtAccessDeniedHandler.handle(request, response,
+                                    new TermsAgreementRequiredException("약관 동의가 필요합니다."));
                             return;
                         }
                     }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/jwt/JwtAuthenticationFilter.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.util.AntPathMatcher;
 
 import java.io.IOException;
 import java.util.Set;
@@ -22,9 +23,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final TokenBlacklistChecker tokenBlacklistChecker;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
+    private static final AntPathMatcher pathMatcher = new AntPathMatcher();
+
     private static final Set<String> TERMS_WHITELIST = Set.of(
-            "/auth/terms/agree",
-            "/auth/terms",
+            "/auth/terms/**",
             "/auth/logout",
             "/auth/withdrawal"
     );
@@ -63,8 +65,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         }
 
                         // 약관동의 미완료 회원 - 화이트리스트 경로 아니면 차단
-                        if (!Boolean.TRUE.equals(userDetails.getMember().getTermsAgreed())
-                                && !TERMS_WHITELIST.contains(request.getRequestURI())) {
+                        boolean isWhitelisted = TERMS_WHITELIST.stream()
+                                .anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()));
+
+                        if (!Boolean.TRUE.equals(userDetails.getMember().getTermsAgreed()) && !isWhitelisted) {
                             jwtAccessDeniedHandler.handle(request, response,
                                     new TermsAgreementRequiredException("약관 동의가 필요합니다."));
                             return;

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/response/code/status/ErrorStatus.java
@@ -46,6 +46,7 @@ public enum ErrorStatus implements BaseCode {
     TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "T001", "약관을 찾을 수 없습니다."),
     REQUIRED_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST, "T002", "필수 약관에 동의하지 않았습니다."),
     DUPLICATE_TERM_ID(HttpStatus.BAD_REQUEST, "T003", "중복된 약관 ID입니다."),
+    TERMS_AGREEMENT_REQUIRED(HttpStatus.FORBIDDEN, "T004", "약관 동의가 필요합니다."),
     
     //재료 관련 에러
     INGREDIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "INGREDIENT4001", "해당 재료를 찾을 수 없습니다."),

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/security/JwtAccessDeniedHandler.java
@@ -32,7 +32,11 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
         response.setCharacterEncoding("UTF-8");
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 
-        ApiResponse<Object> apiResponse = ApiResponse.onFailure(ErrorStatus.FORBIDDEN);
+        ErrorStatus errorStatus = (accessDeniedException instanceof TermsAgreementRequiredException)
+                ? ErrorStatus.TERMS_AGREEMENT_REQUIRED
+                : ErrorStatus.FORBIDDEN;
+
+        ApiResponse<Object> apiResponse = ApiResponse.onFailure(errorStatus);
         objectMapper.writeValue(response.getWriter(), apiResponse);
     }
 }

--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/global/security/TermsAgreementRequiredException.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/global/security/TermsAgreementRequiredException.java
@@ -1,0 +1,9 @@
+package com.mohaemukzip.mohaemukzip_be.global.security;
+
+import org.springframework.security.access.AccessDeniedException;
+
+public class TermsAgreementRequiredException extends AccessDeniedException {
+    public TermsAgreementRequiredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,7 @@ spring:
         hibernate:
             format_sql: true # SQL 로그 포맷팅
 
+
   profiles:
     active: dev
     # include: openai  <-- 제거 (통합하므로 불필요)


### PR DESCRIPTION


## 🎋 작업중인 브랜치 및 이슈

- feat/259-kakao-terms-agreements


## 🔑 주요 변경사항

-  Member 엔티티에 termsAgreed 필드 추가
- 일반/소셜 회원가입 시 약관동의 완료 상태 자동 반영
- 약관동의 미완료 회원의 API 접근을 차단하는 JWT 필터 로직 추가
- /terms/agree API 활성화
- 약관동의 필요 에러코드(T004) 추가

- Set.contains() 정확 일치 방식은 하위 경로 확장 시 취약
- AntPathMatcher.match()로 패턴 기반 매칭으로 변경 (/auth/terms/**)


## Check List
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 소셜 로그인 후 약관 동의 절차를 완료할 수 있게 되었습니다.
  * 회원의 약관 동의 상태가 저장되어 이후 요청 처리에 반영됩니다.

* **Bug Fixes**
  * 약관 동의가 필요한 경우, 관련 화면/요청에서 403 응답과 함께 명확한 안내가 표시되도록 개선했습니다.
  * 회원가입 및 약관 재동의 처리 시 동의 상태가 정확히 갱신되도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->