### PR TITLE
fix: 카카오/애플 로그인 시 탈퇴 회원 재활성화 처리 추가

### DIFF
--- a/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/auth/AuthCommandServiceImpl.java
+++ b/src/main/java/com/mohaemukzip/mohaemukzip_be/domain/member/service/command/auth/AuthCommandServiceImpl.java
@@ -107,7 +107,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         }
 
         if (member.isInactive()) {
-            throw new BusinessException(ErrorStatus.ALREADY_WITHDRAWN_MEMBER);
+            member.reactivate();
         }
 
         return generateAndSaveTokens(member, isNewMember.get());
@@ -133,7 +133,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         }
 
         if (member.isInactive()) {
-            throw new BusinessException(ErrorStatus.ALREADY_WITHDRAWN_MEMBER);
+            member.reactivate();
         }
 
         return generateAndSaveTokens(member, isNewMember.get());


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- fix/271-reactivate-oauthId


## 🔑 주요 변경사항

- `kakaoLogin()`, `appleLogin()`에서 탈퇴 회원(`isInactive() == true`) 재로그인 시
  예외를 던지는 대신 `member.reactivate()`를 호출하여 계정을 재활성화하도록 변경
- 일반 로그인(`login()`)은 이번 변경에서 제외 (기존 정책 유지)



## Check List
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 카카오 및 애플 로그인 시 비활성화된 계정이 자동으로 재활성화되도록 변경했습니다.
  * 재활성화 후 정상적으로 로그인 토큰이 발급됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->